### PR TITLE
test(discovery/consul): speed up test execution by t.Parallel()

### DIFF
--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -15,6 +15,7 @@ package consul
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -49,6 +50,8 @@ func NewTestMetrics(t *testing.T, conf discovery.Config, reg prometheus.Register
 }
 
 func TestConfiguredService(t *testing.T) {
+	t.Parallel()
+
 	conf := &SDConfig{
 		Services: []string{"configuredServiceName"},
 	}
@@ -64,6 +67,8 @@ func TestConfiguredService(t *testing.T) {
 }
 
 func TestConfiguredServiceWithTag(t *testing.T) {
+	t.Parallel()
+
 	conf := &SDConfig{
 		Services:    []string{"configuredServiceName"},
 		ServiceTags: []string{"http"},
@@ -87,6 +92,8 @@ func TestConfiguredServiceWithTag(t *testing.T) {
 }
 
 func TestConfiguredServiceWithTags(t *testing.T) {
+	t.Parallel()
+
 	type testcase struct {
 		// What we've configured to watch.
 		conf *SDConfig
@@ -163,17 +170,24 @@ func TestConfiguredServiceWithTags(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		metrics := NewTestMetrics(t, tc.conf, prometheus.NewRegistry())
+		tc := tc
+		t.Run(fmt.Sprintf("service=%s,tags=%v,shouldWatch=%v", tc.serviceName, tc.serviceTags, tc.shouldWatch), func(t *testing.T) {
+			t.Parallel()
 
-		consulDiscovery, err := NewDiscovery(tc.conf, nil, metrics)
-		require.NoError(t, err, "when initializing discovery")
-		ret := consulDiscovery.shouldWatch(tc.serviceName, tc.serviceTags)
-		require.Equal(t, tc.shouldWatch, ret, "Watched service and tags: %s %+v, input was %s %+v",
-			tc.conf.Services, tc.conf.ServiceTags, tc.serviceName, tc.serviceTags)
+			metrics := NewTestMetrics(t, tc.conf, prometheus.NewRegistry())
+
+			consulDiscovery, err := NewDiscovery(tc.conf, nil, metrics)
+			require.NoError(t, err, "when initializing discovery")
+			ret := consulDiscovery.shouldWatch(tc.serviceName, tc.serviceTags)
+			require.Equal(t, tc.shouldWatch, ret, "Watched service and tags: %s %+v, input was %s %+v",
+				tc.conf.Services, tc.conf.ServiceTags, tc.serviceName, tc.serviceTags)
+		})
 	}
 }
 
 func TestNonConfiguredService(t *testing.T) {
+	t.Parallel()
+
 	conf := &SDConfig{}
 
 	metrics := NewTestMetrics(t, conf, prometheus.NewRegistry())
@@ -294,6 +308,8 @@ func checkOneTarget(t *testing.T, tg []*targetgroup.Group) {
 
 // Watch all the services in the catalog.
 func TestAllServices(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 
@@ -313,6 +329,8 @@ func TestAllServices(t *testing.T) {
 
 // targetgroup with no targets is emitted if no services were discovered.
 func TestNoTargets(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 	config.ServiceTags = []string{"missing"}
@@ -334,6 +352,8 @@ func TestNoTargets(t *testing.T) {
 
 // Watch only the test service.
 func TestOneService(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 
@@ -349,6 +369,8 @@ func TestOneService(t *testing.T) {
 
 // Watch the test service with a specific tag and node-meta.
 func TestAllOptions(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 
@@ -373,6 +395,8 @@ func TestAllOptions(t *testing.T) {
 
 // Watch the test service with a specific tag and node-meta via Filter parameter.
 func TestFilterOption(t *testing.T) {
+	t.Parallel()
+
 	stub, config := newServer(t)
 	defer stub.Close()
 
@@ -393,11 +417,15 @@ func TestFilterOption(t *testing.T) {
 }
 
 func TestGetDatacenterShouldReturnError(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
+		name       string
 		handler    func(http.ResponseWriter, *http.Request)
 		errMessage string
 	}{
 		{
+			name: "500 status code",
 			// Define a handler that will return status 500.
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -405,6 +433,7 @@ func TestGetDatacenterShouldReturnError(t *testing.T) {
 			errMessage: "Unexpected response code: 500 ()",
 		},
 		{
+			name: "incorrect response format",
 			// Define a handler that will return incorrect response.
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Write([]byte(`{"Config": {"Not-Datacenter": "test-dc"}}`))
@@ -412,31 +441,38 @@ func TestGetDatacenterShouldReturnError(t *testing.T) {
 			errMessage: "invalid value '<nil>' for Config.Datacenter",
 		},
 	} {
-		stub := httptest.NewServer(http.HandlerFunc(tc.handler))
-		stuburl, err := url.Parse(stub.URL)
-		require.NoError(t, err)
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		config := &SDConfig{
-			Server:          stuburl.Host,
-			Token:           "fake-token",
-			RefreshInterval: model.Duration(1 * time.Second),
-		}
-		defer stub.Close()
-		d := newDiscovery(t, config)
+			stub := httptest.NewServer(http.HandlerFunc(tc.handler))
+			stuburl, err := url.Parse(stub.URL)
+			require.NoError(t, err)
 
-		// Should be empty if not initialized.
-		require.Empty(t, d.clientDatacenter)
+			config := &SDConfig{
+				Server:          stuburl.Host,
+				Token:           "fake-token",
+				RefreshInterval: model.Duration(1 * time.Second),
+			}
+			defer stub.Close()
+			d := newDiscovery(t, config)
 
-		err = d.getDatacenter()
+			// Should be empty if not initialized.
+			require.Empty(t, d.clientDatacenter)
 
-		// An error should be returned.
-		require.EqualError(t, err, tc.errMessage)
-		// Should still be empty.
-		require.Empty(t, d.clientDatacenter)
+			err = d.getDatacenter()
+
+			// An error should be returned.
+			require.EqualError(t, err, tc.errMessage)
+			// Should still be empty.
+			require.Empty(t, d.clientDatacenter)
+		})
 	}
 }
 
 func TestUnmarshalConfig(t *testing.T) {
+	t.Parallel()
+
 	unmarshal := func(d []byte) func(any) error {
 		return func(o any) error {
 			return yaml.Unmarshal(d, o)
@@ -508,6 +544,8 @@ oauth2:
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			var config SDConfig
 			err := config.UnmarshalYAML(unmarshal([]byte(test.config)))
 			if err != nil {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:

<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enabled broader parallel execution and converted per-case checks into parallel subtests to speed up CI runs.
  - Improved test isolation and reduced cross-test interference by scoping each case as its own subtest with clearer names.
  - No changes to product behavior — updates are confined to test structure and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->