### PR TITLE
feat(remote): add support for type and unit labels in write handler

### DIFF
--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -130,7 +130,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 			}
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -237,7 +237,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 			}
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2}, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2}, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -272,7 +272,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 		}
 
 		appendable := &mockAppendable{}
-		handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2}, false)
+		handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2}, false, false)
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, req)
@@ -301,7 +301,7 @@ func TestRemoteWriteHandler_V1Message(t *testing.T) {
 	// in Prometheus, so keeping like this to not break existing 1.0 clients.
 
 	appendable := &mockAppendable{}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -533,7 +533,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 				appendExemplarErr:     tc.appendExemplarErr,
 				updateMetadataErr:     tc.updateMetadataErr,
 			}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2}, tc.ingestCTZeroSample)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2}, tc.ingestCTZeroSample, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -655,7 +655,7 @@ func TestOutOfOrderSample_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -697,7 +697,7 @@ func TestOutOfOrderExemplar_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -735,7 +735,7 @@ func TestOutOfOrderHistogram_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -785,7 +785,7 @@ func BenchmarkRemoteWriteHandler(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{tc.protoFormat}, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{tc.protoFormat}, false, false)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
@@ -810,7 +810,7 @@ func TestCommitErr_V1Message(t *testing.T) {
 	require.NoError(t, err)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -877,7 +877,7 @@ func TestHistogramValidationErrorHandling(t *testing.T) {
 				require.NoError(t, err)
 				t.Cleanup(func() { require.NoError(t, db.Close()) })
 
-				handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []config.RemoteWriteProtoMsg{protoMsg}, false)
+				handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []config.RemoteWriteProtoMsg{protoMsg}, false, false)
 				recorder := httptest.NewRecorder()
 
 				var buf []byte
@@ -922,7 +922,7 @@ func TestCommitErr_V2Message(t *testing.T) {
 	req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2}, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2}, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -949,7 +949,7 @@ func BenchmarkRemoteWriteOOOSamples(b *testing.B) {
 		require.NoError(b, db.Close())
 	})
 	// TODO: test with other proto format(s)
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false, false)
 
 	buf, _, _, err := buildWriteRequest(nil, genSeriesWithSample(1000, 200*time.Minute.Milliseconds()), nil, nil, nil, nil, "snappy")
 	require.NoError(b, err)
@@ -1280,7 +1280,7 @@ func TestHistogramsReduction(t *testing.T) {
 	for _, protoMsg := range []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2} {
 		t.Run(string(protoMsg), func(t *testing.T) {
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{protoMsg}, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{protoMsg}, false, false)
 
 			var (
 				err     error

--- a/storage/remote/write_handler_type_unit_test.go
+++ b/storage/remote/write_handler_type_unit_test.go
@@ -1,0 +1,223 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
+)
+
+func TestRemoteWriteHandler_TypeAndUnitLabels(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                    string
+		enableTypeAndUnitLabels bool
+		metricType              writev2.Metadata_MetricType
+		unit                    string
+		expectedLabels          labels.Labels
+	}{
+		{
+			name:                    "type and unit labels enabled with counter and bytes unit",
+			enableTypeAndUnitLabels: true,
+			metricType:              writev2.Metadata_METRIC_TYPE_COUNTER,
+			unit:                    "bytes",
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"__type__", "counter",
+				"__unit__", "bytes",
+				"foo", "bar",
+			),
+		},
+		{
+			name:                    "type and unit labels enabled with gauge and seconds unit",
+			enableTypeAndUnitLabels: true,
+			metricType:              writev2.Metadata_METRIC_TYPE_GAUGE,
+			unit:                    "seconds",
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"__type__", "gauge",
+				"__unit__", "seconds",
+				"foo", "bar",
+			),
+		},
+		{
+			name:                    "type and unit labels disabled - no metadata labels",
+			enableTypeAndUnitLabels: false,
+			metricType:              writev2.Metadata_METRIC_TYPE_COUNTER,
+			unit:                    "bytes",
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"foo", "bar",
+			),
+		},
+		{
+			name:                    "type and unit labels enabled but no metadata",
+			enableTypeAndUnitLabels: true,
+			metricType:              writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+			unit:                    "",
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"foo", "bar",
+			),
+		},
+		{
+			name:                    "type and unit labels enabled with only unit (no type)",
+			enableTypeAndUnitLabels: true,
+			metricType:              writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+			unit:                    "milliseconds",
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"__unit__", "milliseconds",
+				"foo", "bar",
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			appendable := &mockAppendable{}
+			handler := NewWriteHandler(
+				slog.Default(),
+				nil,
+				appendable,
+				[]config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV2},
+				false, // ingestCTZeroSample
+				tc.enableTypeAndUnitLabels,
+			)
+
+			// Build a v2 write request with metadata
+			symbolTable := writev2.NewSymbolTable()
+			labelRefs := symbolTable.SymbolizeLabels(
+				labels.FromStrings("__name__", "test_metric", "foo", "bar"),
+				nil,
+			)
+
+			var unitRef uint32
+			if tc.unit != "" {
+				unitRef = symbolTable.Symbolize(tc.unit)
+			}
+
+			req := &writev2.Request{
+				Symbols: symbolTable.Symbols(),
+				Timeseries: []writev2.TimeSeries{
+					{
+						LabelsRefs: labelRefs,
+						Metadata: writev2.Metadata{
+							Type:    tc.metricType,
+							UnitRef: unitRef,
+						},
+						Samples: []writev2.Sample{
+							{Value: 1.0, Timestamp: 1000},
+						},
+					},
+				},
+			}
+
+			// Marshal the request
+			data, _, _, err := buildV2WriteRequest(
+				slog.Default(),
+				req.Timeseries,
+				req.Symbols,
+				nil,
+				nil,
+				nil,
+				"snappy",
+			)
+			require.NoError(t, err)
+
+			// Create HTTP request
+			httpReq, err := http.NewRequest("POST", "/api/v1/write", bytes.NewReader(data))
+			require.NoError(t, err)
+			httpReq.Header.Set("Content-Type", remoteWriteContentTypeHeaders[config.RemoteWriteProtoMsgV2])
+			httpReq.Header.Set("Content-Encoding", "snappy")
+			httpReq.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httpReq)
+
+			resp := recorder.Result()
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusNoContent, resp.StatusCode, "response body: %s", string(body))
+
+			// Verify the labels
+			require.Len(t, appendable.samples, 1)
+			require.Equal(t, tc.expectedLabels, appendable.samples[0].l)
+		})
+	}
+}
+
+func TestRemoteWriteHandler_V1DoesNotAddTypeAndUnitLabels(t *testing.T) {
+	t.Parallel()
+
+	// Even with type and unit labels enabled, v1 should not add them
+	// since v1 doesn't have metadata in the TimeSeries
+	appendable := &mockAppendable{}
+	handler := NewWriteHandler(
+		slog.Default(),
+		nil,
+		appendable,
+		[]config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1},
+		false, // ingestCTZeroSample
+		true,  // enableTypeAndUnitLabels - should have no effect on v1
+	)
+
+	req := &prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "test_metric"},
+					{Name: "foo", Value: "bar"},
+				},
+				Samples: []prompb.Sample{
+					{Value: 1.0, Timestamp: 1000},
+				},
+			},
+		},
+	}
+
+	data, _, _, err := buildWriteRequest(nil, req.Timeseries, nil, nil, nil, nil, "snappy")
+	require.NoError(t, err)
+
+	httpReq, err := http.NewRequest("POST", "/api/v1/write", bytes.NewReader(data))
+	require.NoError(t, err)
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	httpReq.Header.Set("Content-Encoding", "snappy")
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httpReq)
+
+	resp := recorder.Result()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Verify no type/unit labels were added
+	require.Len(t, appendable.samples, 1)
+	expectedLabels := labels.FromStrings("__name__", "test_metric", "foo", "bar")
+	require.Equal(t, expectedLabels, appendable.samples[0].l)
+}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -335,7 +335,7 @@ func NewAPI(
 	}
 
 	if rwEnabled {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs, ctZeroIngestionEnabled)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs, ctZeroIngestionEnabled, enableTypeAndUnitLabels)
 	}
 	if otlpEnabled {
 		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, registerer, ap, configFunc, remote.OTLPOptions{


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] Remote-write: Fix type and unit labels not being propagated to Prometheus receiver when using remote-write v2 with type-and-unit-labels feature flag enabled.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional setting to inject metric type and unit labels (__type__, __unit__) during Remote Write v2 ingestion; disabled by default and v1 remains unaffected.

* **Tests**
  * Added unit tests covering enabled/disabled behavior, UNSPECIFIED metadata, v1 unaffected, and end-to-end label composition and responses.

* **Chores**
  * Public initializer updated to accept an extra boolean flag to control the new labeling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->