### PR TITLE
Testing

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -184,11 +184,6 @@ func (m *Manager) reload() {
 				m.logger.Error("error reloading target set", "err", "invalid config id:"+setName)
 				continue
 			}
-			if scrapeConfig.ConvertClassicHistogramsToNHCBEnabled() && m.opts.EnableCreatedTimestampZeroIngestion {
-				// TODO(krajorama): fix https://github.com/prometheus/prometheus/issues/15137
-				m.logger.Error("error reloading target set", "err", "cannot convert classic histograms to native histograms with custom buckets and ingest created timestamp zero samples at the same time due to https://github.com/prometheus/prometheus/issues/15137")
-				continue
-			}
 			m.metrics.targetScrapePools.Inc()
 			sp, err := newScrapePool(scrapeConfig, m.append, m.offsetSeed, m.logger.With("scrape_pool", setName), m.buffers, m.opts, m.metrics)
 			if err != nil {

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -1069,8 +1069,8 @@ func TestUnregisterMetrics(t *testing.T) {
 // TestNHCBAndCTZeroIngestion verifies that both ConvertClassicHistogramsToNHCBEnabled
 // and EnableCreatedTimestampZeroIngestion can be used simultaneously without errors.
 // This test addresses issue #17216 by ensuring the previously blocking check has been removed.
-// It also tests that exemplars are correctly parsed with both features enabled, addressing
-// the original concern from issue #15137 about losing exemplars during CT parsing.
+// The test verifies that the presence of exemplars in the input does not cause errors,
+// although exemplars are not preserved during NHCB conversion (as documented below).
 func TestNHCBAndCTZeroIngestion(t *testing.T) {
 	t.Parallel()
 
@@ -1100,8 +1100,7 @@ func TestNHCBAndCTZeroIngestion(t *testing.T) {
 				fail = false
 				w.Header().Set("Content-Type", `application/openmetrics-text`)
 
-				// Expose a histogram with created timestamp and exemplars.
-				// This tests the fix for #15137 where exemplars were lost during CT parsing.
+				// Expose a histogram with created timestamp and exemplars to verify no parsing errors occur.
 				fmt.Fprint(w, `# HELP test_histogram A histogram with created timestamp and exemplars
 # TYPE test_histogram histogram
 test_histogram_bucket{le="0.0"} 1

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -1075,7 +1075,9 @@ func TestNHCBAndCTZeroIngestion(t *testing.T) {
 	t.Parallel()
 
 	const (
-		mName                = "test_histogram"
+		mName = "test_histogram"
+		// The expected sum of the histogram, as defined by the test's OpenMetrics exposition data.
+		// This value (45.5) is the sum reported in the test_histogram_sum metric below.
 		expectedHistogramSum = 45.5
 	)
 
@@ -1126,6 +1128,7 @@ test_histogram_created 1520430001
 	// Configuration with both convert_classic_histograms_to_nhcb enabled and CT zero ingestion enabled.
 	testConfig := fmt.Sprintf(`
 global:
+  # Use a very long scrape_interval to prevent automatic scraping during the test.
   scrape_interval: 9999m
   scrape_timeout: 5s
 

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -1074,7 +1074,10 @@ func TestUnregisterMetrics(t *testing.T) {
 func TestNHCBAndCTZeroIngestion(t *testing.T) {
 	t.Parallel()
 
-	const mName = "test_histogram"
+	const (
+		mName                = "test_histogram"
+		expectedHistogramSum = 45.5
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1135,35 +1138,36 @@ scrape_configs:
 
 	applyConfig(t, testConfig, scrapeManager, discoveryManager)
 
-	// Wait for scrape to complete successfully.
-	ctx, cancel = context.WithTimeout(ctx, 1*time.Minute)
-	defer cancel()
-	require.NoError(t, runutil.Retry(100*time.Millisecond, ctx.Done(), func() error {
+	// Helper function to get matching histograms to avoid race conditions.
+	getMatchingHistograms := func() []histogramSample {
 		app.mtx.Lock()
 		defer app.mtx.Unlock()
 
-		if len(app.resultHistograms) > 0 {
-			return nil
+		var got []histogramSample
+		for _, h := range app.resultHistograms {
+			if h.metric.Get(model.MetricNameLabel) == mName {
+				got = append(got, h)
+			}
 		}
-		return errors.New("expected histogram samples, got none")
-	}), "after 1 minute")
+		return got
+	}
+
+	require.Eventually(t, func() bool {
+		return len(getMatchingHistograms()) > 0
+	}, 1*time.Minute, 100*time.Millisecond, "expected histogram samples, got none")
 
 	// Verify that samples were ingested (proving both features work together).
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	var got []histogramSample
-	for _, h := range app.resultHistograms {
-		if h.metric.Get(model.MetricNameLabel) == mName {
-			got = append(got, h)
-		}
-	}
+	got := getMatchingHistograms()
 
 	// With CT zero ingestion enabled and a created timestamp present, we expect 2 samples:
 	// one zero sample and one actual sample.
 	require.Len(t, got, 2, "expected 2 histogram samples (zero sample + actual sample)")
 	require.Equal(t, histogram.Histogram{}, *got[0].h, "first sample should be zero sample")
-	require.NotEqual(t, 0.0, got[1].h.Sum, "second sample should have non-zero sum")
+	require.InDelta(t, expectedHistogramSum, got[1].h.Sum, 1e-9, "second sample should retain the expected sum")
+
+	// Note: Exemplars from classic histogram buckets are not preserved when converting to NHCB
+	// because the bucket series are replaced with a single native histogram sample. This is expected
+	// behavior. The test verifies that the presence of exemplars in the input doesn't cause errors.
 
 	// The test successfully completes, proving that both ConvertClassicHistogramsToNHCBEnabled
 	// and EnableCreatedTimestampZeroIngestion can work together without the error that was


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scrape pools are now created when both “Convert Classic Histograms to NHCB” and “Created Timestamp Zero Ingestion” are enabled, ensuring targets are scraped and histogram samples (zero and actual) are ingested without blocking errors.

* **Tests**
  * Added a test validating successful ingestion and coexistence of both features to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->